### PR TITLE
Fix for obsolete pre-build option.

### DIFF
--- a/UnityProject/Assets/LoomSDK/Source/Editor/CheckProject.cs
+++ b/UnityProject/Assets/LoomSDK/Source/Editor/CheckProject.cs
@@ -36,10 +36,13 @@ namespace Loom.Client.Unity.Editor.Internal
             if (target == BuildTarget.WebGL)
             {
                 CheckWebGLTemplate();
+#if !UNITY_2019_1_OR_NEWER
                 CheckWebGLPrebuiltEngine();
+#endif
             }
         }
 
+#if !UNITY_2019_1_OR_NEWER
         private void CheckWebGLPrebuiltEngine()
         {
             if (!EditorUserBuildSettings.webGLUsePreBuiltUnityEngine)
@@ -58,6 +61,7 @@ namespace Loom.Client.Unity.Editor.Internal
                 EditorUserBuildSettings.webGLUsePreBuiltUnityEngine = false;
             }
         }
+#endif
 
         private void CheckWebGLTemplate()
         {


### PR DESCRIPTION
In Unity 2019.1.x you get the following error message for a no longer supported building option:
Assets\LoomSDK\Source\Editor\CheckProject.cs(45,18): error CS0619: 'EditorUserBuildSettings.webGLUsePreBuiltUnityEngine' is obsolete: 'Building with pre-built Engine option is no longer supported.'

This PR removes the function definition and function call for Unity 2019.1.x and newer versions.